### PR TITLE
Update auth flow for encryption key

### DIFF
--- a/src/components/RecoveryKeyDisplay.tsx
+++ b/src/components/RecoveryKeyDisplay.tsx
@@ -1,30 +1,30 @@
-// src/components/RecoveryCodeDisplay.tsx
+// src/components/RecoveryKeyDisplay.tsx
 import React, { useState } from 'react';
 
-interface RecoveryCodeDisplayProps {
-  recoveryCode: string;
+interface RecoveryKeyDisplayProps {
+  recoveryKey: string;
   onContinue: () => void;
 }
 
-const RecoveryCodeDisplay: React.FC<RecoveryCodeDisplayProps> = ({ 
-  recoveryCode,
-  onContinue
+const RecoveryKeyDisplay: React.FC<RecoveryKeyDisplayProps> = ({
+  recoveryKey,
+  onContinue,
 }) => {
   const [confirmed, setConfirmed] = useState(false);
   
   return (
     <div className="bg-white rounded-lg p-6 max-w-md w-full">
-      <h2 className="text-xl font-bold mb-4">Save Your Recovery Code</h2>
+      <h2 className="text-xl font-bold mb-4">Save Your Recovery Key</h2>
       
       <p className="mb-4 text-gray-600">
-        Your data is protected with end-to-end encryption. If you ever forget your 
-        passphrase, you can use this recovery code to access your data.
+        Your data is protected with end-to-end encryption. If you ever forget your
+        encryption key, you can use this recovery key to access your data.
       </p>
       
       <div className="bg-yellow-50 border border-yellow-400 p-4 rounded-md mb-6">
         <p className="font-bold text-yellow-800 mb-2">IMPORTANT:</p>
         <p className="text-yellow-800 mb-2">
-          Write down this code and keep it in a safe place. We cannot reset or recover 
+          Write down this key and keep it in a safe place. We cannot reset or recover
           your data without it.
         </p>
         <p className="text-yellow-800">
@@ -33,7 +33,7 @@ const RecoveryCodeDisplay: React.FC<RecoveryCodeDisplayProps> = ({
       </div>
       
       <div className="bg-gray-100 p-3 rounded-md text-center mb-6">
-        <p className="font-mono text-xl tracking-wider select-all">{recoveryCode}</p>
+        <p className="font-mono text-xl tracking-wider select-all">{recoveryKey}</p>
       </div>
       
       <div className="flex items-center mb-6">
@@ -45,7 +45,7 @@ const RecoveryCodeDisplay: React.FC<RecoveryCodeDisplayProps> = ({
           className="mr-2"
         />
         <label htmlFor="confirm-checkbox">
-          I have saved my recovery code in a safe place
+          I have saved my recovery key in a safe place
         </label>
       </div>
       
@@ -66,4 +66,4 @@ const RecoveryCodeDisplay: React.FC<RecoveryCodeDisplayProps> = ({
   );
 };
 
-export default RecoveryCodeDisplay;
+export default RecoveryKeyDisplay;

--- a/src/components/RecoveryModal.tsx
+++ b/src/components/RecoveryModal.tsx
@@ -13,7 +13,7 @@ const RecoveryModal: React.FC<RecoveryModalProps> = ({
   onSuccess, 
   onCancel 
 }) => {
-  const [method, setMethod] = useState<'passphrase' | 'recoveryCode'>('passphrase');
+  const [method, setMethod] = useState<'encryptionKey' | 'recoveryKey'>('encryptionKey');
   const [input, setInput] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -26,7 +26,7 @@ const RecoveryModal: React.FC<RecoveryModalProps> = ({
     try {
       let isValid = false;
       
-      if (method === 'passphrase') {
+      if (method === 'encryptionKey') {
         isValid = await recoverWithPassphrase(input);
       } else {
         isValid = await recoverWithCode(input);
@@ -35,7 +35,7 @@ const RecoveryModal: React.FC<RecoveryModalProps> = ({
       if (isValid) {
         onSuccess();
       } else {
-        setError(`Invalid ${method === 'passphrase' ? 'passphrase' : 'recovery code'}. Please try again.`);
+        setError(`Invalid ${method === 'encryptionKey' ? 'encryption key' : 'recovery key'}. Please try again.`);
       }
     } catch (err) {
       setError(`Error during recovery. Please try again.`);
@@ -52,40 +52,40 @@ const RecoveryModal: React.FC<RecoveryModalProps> = ({
       <div className="bg-white rounded-lg p-6 max-w-md w-full">
         <h2 className="text-xl font-bold mb-4">Recover Account Access</h2>
         <p className="mb-4 text-gray-600">
-          Your data is protected with encryption. Please enter your 
-          {method === 'passphrase' ? ' passphrase' : ' recovery code'} to access your data.
+          Your data is protected with encryption. Please enter your
+          {method === 'encryptionKey' ? ' encryption key' : ' recovery key'} to access your data.
         </p>
         
         <div className="flex space-x-2 mb-4">
           <button
             type="button"
-            onClick={() => setMethod('passphrase')}
+            onClick={() => setMethod('encryptionKey')}
             className={`px-3 py-1 rounded ${
-              method === 'passphrase' 
+              method === 'encryptionKey'
                 ? 'bg-blue-500 text-white' 
                 : 'bg-gray-200 text-gray-700'
             }`}
           >
-            Use Passphrase
+            Use Encryption Key
           </button>
           <button
             type="button"
-            onClick={() => setMethod('recoveryCode')}
+            onClick={() => setMethod('recoveryKey')}
             className={`px-3 py-1 rounded ${
-              method === 'recoveryCode' 
+              method === 'recoveryKey'
                 ? 'bg-blue-500 text-white' 
                 : 'bg-gray-200 text-gray-700'
             }`}
           >
-            Use Recovery Code
+            Use Recovery Key
           </button>
         </div>
         
         <form onSubmit={handleSubmit}>
           <input
-            type={method === 'passphrase' ? 'password' : 'text'}
+            type={method === 'encryptionKey' ? 'password' : 'text'}
             className="w-full p-2 border rounded mb-4"
-            placeholder={method === 'passphrase' ? 'Enter your passphrase' : 'Enter your recovery code (e.g., APPLE-BANANA-CHERRY-1234)'}
+            placeholder={method === 'encryptionKey' ? 'Enter your encryption key' : 'Enter your recovery key (e.g., APPLE-BANANA-CHERRY-1234)'}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             required

--- a/src/components/auth/SignUp.tsx
+++ b/src/components/auth/SignUp.tsx
@@ -19,7 +19,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import RecoveryCodeDisplay from '@/components/RecoveryCodeDisplay';
+import RecoveryKeyDisplay from '@/components/RecoveryKeyDisplay';
 
 interface SignUpDialogProps {
   open: boolean;
@@ -33,20 +33,20 @@ export const SignUpDialog = ({ open, onOpenChange }: SignUpDialogProps) => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
-  const [passphrase, setPassphrase] = useState('');
+  const [encryptionKey, setEncryptionKey] = useState('');
   const [termsAccepted, setTermsAccepted] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [recoveryCode, setRecoveryCode] = useState<string | null>(null);
+  const [recoveryKey, setRecoveryKey] = useState<string | null>(null);
 
   const resetForm = () => {
     setStep(0);
     setEmail('');
     setPassword('');
     setConfirmPassword('');
-    setPassphrase('');
+    setEncryptionKey('');
     setTermsAccepted(false);
     setError(null);
-    setRecoveryCode(null);
+    setRecoveryKey(null);
   };
 
   const handleDialogChange = (open: boolean) => {
@@ -59,7 +59,7 @@ export const SignUpDialog = ({ open, onOpenChange }: SignUpDialogProps) => {
   const handleSignUp = async () => {
     setError(null);
 
-    if (!email || !password || !passphrase) {
+    if (!email || !password || !encryptionKey) {
       setError('Please fill in all fields.');
       return;
     }
@@ -74,10 +74,10 @@ export const SignUpDialog = ({ open, onOpenChange }: SignUpDialogProps) => {
 
       setUserUID(user.uid);
 
-      const result = await setupEncryption(passphrase.trim());
-      setRecoveryCode(result.recoveryCode);
+      const result = await setupEncryption(encryptionKey.trim());
+      setRecoveryKey(result.recoveryCode);
 
-      await createUserProfile(user.uid, email.trim(), passphrase.trim());
+      await createUserProfile(user.uid, email.trim(), encryptionKey.trim());
       setStep(5); // Show recovery code screen
 
     } catch (error: any) {
@@ -101,7 +101,7 @@ export const SignUpDialog = ({ open, onOpenChange }: SignUpDialogProps) => {
       if (password !== confirmPassword) return setError('Passwords do not match');
       setStep(3);
     } else if (step === 3) {
-      if (!passphrase || passphrase.length < 8) return setError('Passphrase must be at least 8 characters');
+      if (!encryptionKey || encryptionKey.length < 8) return setError('Encryption key must be at least 8 characters');
       setStep(4);
     } else if (step === 4) {
       if (!termsAccepted) return setError('Please accept the terms');
@@ -133,9 +133,9 @@ export const SignUpDialog = ({ open, onOpenChange }: SignUpDialogProps) => {
           </div>
         </DialogHeader>
 
-        {recoveryCode ? (
+        {recoveryKey ? (
           <div className="py-6">
-            <RecoveryCodeDisplay recoveryCode={recoveryCode} onContinue={handleContinue} />
+            <RecoveryKeyDisplay recoveryKey={recoveryKey} onContinue={handleContinue} />
           </div>
         ) : (
           <div className="py-4">
@@ -171,9 +171,9 @@ export const SignUpDialog = ({ open, onOpenChange }: SignUpDialogProps) => {
 
               {step === 3 && (
                 <div className="space-y-4">
-                  <h3 className="text-sm font-medium">Create a secret passphrase</h3>
+                  <h3 className="text-sm font-medium">Create an encryption key</h3>
                   <p className="text-sm text-muted-foreground">This will encrypt your data. Make it secure and memorable.</p>
-                  <Input type="text" value={passphrase} onChange={(e) => setPassphrase(e.target.value)} required autoFocus placeholder="Passphrase" />
+                  <Input type="text" value={encryptionKey} onChange={(e) => setEncryptionKey(e.target.value)} required autoFocus placeholder="Encryption key" />
                 </div>
               )}
 
@@ -195,7 +195,7 @@ export const SignUpDialog = ({ open, onOpenChange }: SignUpDialogProps) => {
           </div>
         )}
 
-        {!recoveryCode && (
+        {!recoveryKey && (
           <DialogFooter className="flex justify-between sm:justify-between">
             {step > 0 ? (
               <Button variant="outline" onClick={handleBack} type="button">← Back</Button>

--- a/src/hooks/useConversationService.ts
+++ b/src/hooks/useConversationService.ts
@@ -2,6 +2,7 @@
 import { useState, useCallback } from 'react';
 import { useAuth } from './useAuth';
 import * as conversationService from '../utils/conversationService';
+import type { EmotionTrend } from '../utils/conversationService';
 
 interface Message {
   role: 'user' | 'assistant' | 'system';

--- a/src/utils/conversationService.ts
+++ b/src/utils/conversationService.ts
@@ -25,7 +25,7 @@ interface ConversationSession {
   summary?: string;
 }
 
-interface EmotionTrend {
+export interface EmotionTrend {
   date: string;
   emotions: Record<string, number>;
   totalCount: number;


### PR DESCRIPTION
## Summary
- rename passphrase UI to **encryption key**
- prompt for encryption key during signup and login
- show recovery key after signup
- support encryption key recovery via modal

## Testing
- `npm run lint` *(fails: eslint-plugin-react-refresh not found)*
- `npm run typecheck` *(fails: JSX error in ImprovedJournalPage.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6840e96fff088333aef16c48c0532281